### PR TITLE
Replacement tokens but key can't be found -- resolved error.

### DIFF
--- a/Lingual.Tests/TranslationTests.cs
+++ b/Lingual.Tests/TranslationTests.cs
@@ -51,6 +51,20 @@ namespace Lingual.Tests
         }
 
         [Test]
+        public void ItReturnsKeyWhenItCantFindKeyInLocalizedFile()
+        {
+            var cases = new[]
+            {
+                new { key = "this.key.doesnt.exist", tokens = new { prop = (string)null } , answer = "this.key.doesnt.exist" },
+                new { key = "this.key.doesnt.exist", tokens = new { prop = "prop" }, answer = "this.key.doesnt.exist" },
+            };   
+            foreach (var entry in cases)
+            {
+                Assert.AreEqual(entry.answer, translator.Localize(entry.key, null, entry.tokens));
+            }
+        }
+
+        [Test]
         public void ItDoesntBlowUpWithNullParameters()
         {
             var cases = new[]

--- a/Lingual/Lingual.nuspec
+++ b/Lingual/Lingual.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package >
   <metadata>
     <id>Lingual</id>
-    <version>1.3.1.0</version>
+    <version>1.3.2.0</version>
     <title>Lingual</title>
     <authors>Nuvi</authors>
     <owners>Nuvi</owners>
@@ -11,7 +11,7 @@
     <iconUrl>http://www.nuvi.com/images/Layout/small-owl.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>i18n Platform built by Nuvi</description>
-    <releaseNotes>Remove unnecessary Path.Combine</releaseNotes>
+    <releaseNotes>Resolve some edge case exceptions</releaseNotes>
     <copyright>Copyright 2014-2015</copyright>
     <tags>i18n Nuvi</tags>
     <dependencies>

--- a/Lingual/Translator.cs
+++ b/Lingual/Translator.cs
@@ -91,12 +91,20 @@ namespace Lingual
 
         public string ApplyInterpolatedItems(string str, object tokens)
         {
+            if (str == null)
+            {
+                return str;
+            }
             return tokens.GetType().GetProperties()
                 .Aggregate(str, (accumulator, prop) => 
                 {
                     var pattern = string.Format("__{0}__", prop.Name);
-                    var replaceValue = prop.GetValue(tokens, null).ToString();
-                    return Regex.Replace(accumulator, pattern, replaceValue,RegexOptions.IgnoreCase);
+                    var replaceValue = prop.GetValue(tokens, null);
+                    if(replaceValue == null)
+                    {
+                        return accumulator;
+                    }
+                    return Regex.Replace(accumulator, pattern, replaceValue.ToString(),RegexOptions.IgnoreCase);
                 });
         }   
     }


### PR DESCRIPTION
When you provide replacement tokens but the key cannot be be found, it was throwing null exceptions at the Regex.Replace level.

Fixed and added test coverage for that.